### PR TITLE
Modularize API routers and enhance CRM workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+.env
+.venv/
+*.sqlite3
+tour_planner.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,84 @@
-# try-codex
+# Tour Planner API
+
+A FastAPI-based backend for travel and tour agencies to manage clients, build printable itineraries, and track finances.
+
+## Features
+
+- **Itinerary Builder**: Create multi-day itineraries with detailed day plans and generate printable HTML output.
+- **CRM Tools**: Manage clients and leads, capture notes and statuses, and convert warm leads into clients in one click.
+- **Inventory Management**: Store reusable tour packages.
+- **Finance Module**: Issue invoices, record payments and expenses, and view profitability summaries and sales reports with monthly rollups.
+- **Reporting**: Quick summaries for itinerary statuses and monthly sales performance.
+
+## Getting Started
+
+### Requirements
+
+- Python 3.11+
+- `pip` for dependency installation
+
+### Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Running the API
+
+```bash
+uvicorn app.main:app --reload
+```
+
+The API will be available at <http://127.0.0.1:8000>. Interactive documentation is provided at `/docs` (Swagger UI) and `/redoc`.
+
+### Database
+
+SQLite is used by default (stored in `tour_planner.db`). The schema is created automatically on startup. Adjust the connection string in `app/database.py` to target a different database engine.
+
+### Project Structure
+
+```
+app/
+├── api/
+│   ├── __init__.py          # Aggregated API router
+│   ├── deps.py              # Shared FastAPI dependencies
+│   └── routes/              # Modular endpoint definitions
+│       ├── clients.py
+│       ├── finance.py
+│       ├── itineraries.py
+│       ├── leads.py
+│       ├── reports.py
+│       └── tour_packages.py
+├── crud.py          # Database helper operations
+├── database.py      # SQLAlchemy configuration
+├── main.py          # FastAPI application factory
+├── models.py        # SQLAlchemy ORM models
+├── schemas.py       # Pydantic models for validation
+├── templates/       # Jinja2 templates for printable itineraries
+│   └── itinerary.html
+├── utils.py         # Helper utilities
+requirements.txt
+README.md
+```
+
+### Testing
+
+Tests rely on FastAPI's `TestClient` and an in-memory SQLite database.
+
+```bash
+pytest
+```
+
+## API Highlights
+
+- `POST /clients` – create a client record
+- `POST /itineraries` – create an itinerary with day-by-day details
+- `GET /itineraries/{id}/print` – render a printable itinerary document
+- `POST /finance/invoices` – issue an invoice linked to a client or itinerary
+- `POST /leads/{id}/convert` – create a client record from a qualified lead
+- `POST /itineraries/{id}/duplicate` – clone an itinerary as a reusable template
+- `GET /finance/summary` – view totals for invoices, payments, expenses, and profitability
+
+Refer to the auto-generated docs for the full list of endpoints and payload schemas.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Tour Planner application package."""

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,14 @@
+"""API router package for the Tour Planner service."""
+from fastapi import APIRouter
+
+from .routes import clients, finance, itineraries, leads, reports, tour_packages
+
+router = APIRouter()
+router.include_router(clients.router)
+router.include_router(leads.router)
+router.include_router(tour_packages.router)
+router.include_router(itineraries.router)
+router.include_router(finance.router)
+router.include_router(reports.router)
+
+__all__ = ["router"]

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,0 +1,21 @@
+"""Shared FastAPI dependencies."""
+from __future__ import annotations
+
+from typing import Generator
+
+from sqlalchemy.orm import Session
+
+from ..database import SessionLocal
+
+
+def get_db() -> Generator[Session, None, None]:
+    """Provide a scoped database session to request handlers."""
+    db = SessionLocal()
+    try:
+        yield db
+        db.commit()
+    except Exception:  # pragma: no cover - safety rollback
+        db.rollback()
+        raise
+    finally:
+        db.close()

--- a/app/api/routes/clients.py
+++ b/app/api/routes/clients.py
@@ -1,0 +1,63 @@
+"""Client management endpoints."""
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response, status
+from sqlalchemy.orm import Session
+
+from ... import crud, models, schemas
+from ..deps import get_db
+
+router = APIRouter(prefix="/clients", tags=["clients"])
+
+
+@router.post("", response_model=schemas.Client, status_code=status.HTTP_201_CREATED)
+def create_client(client_in: schemas.ClientCreate, db: Session = Depends(get_db)) -> models.Client:
+    return crud.create_client(db, client_in)
+
+
+@router.get("", response_model=List[schemas.Client])
+def list_clients(
+    db: Session = Depends(get_db),
+    search: str | None = Query(None, description="Filter clients by name or email substring"),
+) -> List[models.Client]:
+    clients = crud.list_clients(db)
+    if search:
+        lowered = search.lower()
+        clients = [
+            client
+            for client in clients
+            if lowered in (client.name or "").lower()
+            or lowered in (client.email or "").lower()
+        ]
+    return list(clients)
+
+
+@router.get("/{client_id}", response_model=schemas.Client)
+def get_client(client_id: int = Path(..., gt=0), db: Session = Depends(get_db)) -> models.Client:
+    client = crud.get_client(db, client_id)
+    if not client:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Client not found")
+    return client
+
+
+@router.put("/{client_id}", response_model=schemas.Client)
+def update_client(
+    client_id: int,
+    client_in: schemas.ClientUpdate,
+    db: Session = Depends(get_db),
+) -> models.Client:
+    client = crud.get_client(db, client_id)
+    if not client:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Client not found")
+    return crud.update_client(db, client, client_in)
+
+
+@router.delete("/{client_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_client(client_id: int, db: Session = Depends(get_db)) -> Response:
+    client = crud.get_client(db, client_id)
+    if not client:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Client not found")
+    crud.delete_client(db, client)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/api/routes/finance.py
+++ b/app/api/routes/finance.py
@@ -1,0 +1,150 @@
+"""Finance endpoints covering invoices, payments, and expenses."""
+from __future__ import annotations
+
+from typing import Any, List
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.orm import Session
+
+from ... import crud, models, schemas
+from ...utils import compute_outstanding_balance
+from ..deps import get_db
+
+router = APIRouter(prefix="/finance", tags=["finance"])
+
+
+@router.post("/invoices", response_model=schemas.Invoice, status_code=status.HTTP_201_CREATED)
+def create_invoice(invoice_in: schemas.InvoiceCreate, db: Session = Depends(get_db)) -> models.Invoice:
+    invoice = crud.create_invoice(db, invoice_in)
+    db.refresh(invoice)
+    return invoice
+
+
+@router.get("/invoices", response_model=List[schemas.Invoice])
+def list_invoices(db: Session = Depends(get_db)) -> List[models.Invoice]:
+    return list(crud.list_invoices(db))
+
+
+@router.get("/invoices/{invoice_id}", response_model=schemas.Invoice)
+def get_invoice(invoice_id: int, db: Session = Depends(get_db)) -> models.Invoice:
+    invoice = crud.get_invoice(db, invoice_id)
+    if not invoice:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
+    return invoice
+
+
+@router.put("/invoices/{invoice_id}", response_model=schemas.Invoice)
+def update_invoice(
+    invoice_id: int,
+    invoice_in: schemas.InvoiceUpdate,
+    db: Session = Depends(get_db),
+) -> models.Invoice:
+    invoice = crud.get_invoice(db, invoice_id)
+    if not invoice:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
+    invoice = crud.update_invoice(db, invoice, invoice_in)
+    db.refresh(invoice)
+    return invoice
+
+
+@router.delete("/invoices/{invoice_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_invoice(invoice_id: int, db: Session = Depends(get_db)) -> Response:
+    invoice = crud.get_invoice(db, invoice_id)
+    if not invoice:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
+    crud.delete_invoice(db, invoice)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/payments", response_model=schemas.Payment, status_code=status.HTTP_201_CREATED)
+def create_payment(payment_in: schemas.PaymentCreate, db: Session = Depends(get_db)) -> models.Payment:
+    payment = crud.create_payment(db, payment_in)
+    db.refresh(payment)
+    return payment
+
+
+@router.get("/payments", response_model=List[schemas.Payment])
+def list_payments(db: Session = Depends(get_db)) -> List[models.Payment]:
+    return list(crud.list_payments(db))
+
+
+@router.put("/payments/{payment_id}", response_model=schemas.Payment)
+def update_payment(
+    payment_id: int,
+    payment_in: schemas.PaymentUpdate,
+    db: Session = Depends(get_db),
+) -> models.Payment:
+    payment = crud.get_payment(db, payment_id)
+    if not payment:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Payment not found")
+    payment = crud.update_payment(db, payment, payment_in)
+    db.refresh(payment)
+    return payment
+
+
+@router.delete("/payments/{payment_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_payment(payment_id: int, db: Session = Depends(get_db)) -> Response:
+    payment = crud.get_payment(db, payment_id)
+    if not payment:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Payment not found")
+    crud.delete_payment(db, payment)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/expenses", response_model=schemas.Expense, status_code=status.HTTP_201_CREATED)
+def create_expense(expense_in: schemas.ExpenseCreate, db: Session = Depends(get_db)) -> models.Expense:
+    expense = crud.create_expense(db, expense_in)
+    db.refresh(expense)
+    return expense
+
+
+@router.get("/expenses", response_model=List[schemas.Expense])
+def list_expenses(db: Session = Depends(get_db)) -> List[models.Expense]:
+    return list(crud.list_expenses(db))
+
+
+@router.put("/expenses/{expense_id}", response_model=schemas.Expense)
+def update_expense(
+    expense_id: int,
+    expense_in: schemas.ExpenseUpdate,
+    db: Session = Depends(get_db),
+) -> models.Expense:
+    expense = crud.get_expense(db, expense_id)
+    if not expense:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Expense not found")
+    expense = crud.update_expense(db, expense, expense_in)
+    db.refresh(expense)
+    return expense
+
+
+@router.delete("/expenses/{expense_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_expense(expense_id: int, db: Session = Depends(get_db)) -> Response:
+    expense = crud.get_expense(db, expense_id)
+    if not expense:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Expense not found")
+    crud.delete_expense(db, expense)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/summary")
+def finance_summary(db: Session = Depends(get_db)) -> dict[str, Any]:
+    invoices: List[models.Invoice] = list(crud.list_invoices(db))
+    payments: List[models.Payment] = list(crud.list_payments(db))
+    expenses: List[models.Expense] = list(crud.list_expenses(db))
+
+    total_invoiced = sum(float(invoice.amount) for invoice in invoices)
+    total_paid = sum(float(payment.amount) for payment in payments)
+    total_expenses = sum(float(expense.amount) for expense in expenses)
+
+    outstanding = sum(
+        compute_outstanding_balance(invoice.payments, float(invoice.amount)) for invoice in invoices
+    )
+    profitability = round(total_paid - total_expenses, 2)
+
+    return {
+        "total_invoiced": round(total_invoiced, 2),
+        "total_paid": round(total_paid, 2),
+        "total_expenses": round(total_expenses, 2),
+        "outstanding": round(outstanding, 2),
+        "profitability": profitability,
+    }

--- a/app/api/routes/leads.py
+++ b/app/api/routes/leads.py
@@ -1,0 +1,52 @@
+"""CRM lead endpoints."""
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.orm import Session
+
+from ... import crud, models, schemas
+from ..deps import get_db
+
+router = APIRouter(prefix="/leads", tags=["crm"])
+
+
+@router.post("", response_model=schemas.Lead, status_code=status.HTTP_201_CREATED)
+def create_lead(lead_in: schemas.LeadCreate, db: Session = Depends(get_db)) -> models.Lead:
+    return crud.create_lead(db, lead_in)
+
+
+@router.get("", response_model=List[schemas.Lead])
+def list_leads(db: Session = Depends(get_db)) -> List[models.Lead]:
+    return list(crud.list_leads(db))
+
+
+@router.put("/{lead_id}", response_model=schemas.Lead)
+def update_lead(
+    lead_id: int,
+    lead_in: schemas.LeadUpdate,
+    db: Session = Depends(get_db),
+) -> models.Lead:
+    lead = crud.get_lead(db, lead_id)
+    if not lead:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Lead not found")
+    return crud.update_lead(db, lead, lead_in)
+
+
+@router.post("/{lead_id}/convert", response_model=schemas.LeadConversionResult)
+def convert_lead(lead_id: int, db: Session = Depends(get_db)) -> schemas.LeadConversionResult:
+    lead = crud.get_lead(db, lead_id)
+    if not lead:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Lead not found")
+    client = crud.convert_lead_to_client(db, lead)
+    return schemas.LeadConversionResult(lead=lead, client=client)
+
+
+@router.delete("/{lead_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_lead(lead_id: int, db: Session = Depends(get_db)) -> Response:
+    lead = crud.get_lead(db, lead_id)
+    if not lead:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Lead not found")
+    crud.delete_lead(db, lead)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/api/routes/reports.py
+++ b/app/api/routes/reports.py
@@ -1,0 +1,26 @@
+"""Reporting endpoints for operational insights."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ... import crud
+from ..deps import get_db
+
+router = APIRouter(prefix="/reports", tags=["reports"])
+
+
+@router.get("/itinerary-status")
+def itinerary_status_report(db: Session = Depends(get_db)) -> dict[str, Any]:
+    itineraries = list(crud.list_itineraries(db))
+    statuses: dict[str, int] = {}
+    for itinerary in itineraries:
+        statuses[itinerary.status] = statuses.get(itinerary.status, 0) + 1
+    return {"counts": statuses, "total": len(itineraries)}
+
+
+@router.get("/sales")
+def sales_report(db: Session = Depends(get_db)) -> dict[str, Any]:
+    return crud.sales_report(db)

--- a/app/api/routes/tour_packages.py
+++ b/app/api/routes/tour_packages.py
@@ -1,0 +1,45 @@
+"""Tour package inventory endpoints."""
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.orm import Session
+
+from ... import crud, models, schemas
+from ..deps import get_db
+
+router = APIRouter(prefix="/packages", tags=["inventory"])
+
+
+@router.post("", response_model=schemas.TourPackage, status_code=status.HTTP_201_CREATED)
+def create_package(
+    package_in: schemas.TourPackageCreate, db: Session = Depends(get_db)
+) -> models.TourPackage:
+    return crud.create_tour_package(db, package_in)
+
+
+@router.get("", response_model=List[schemas.TourPackage])
+def list_packages(db: Session = Depends(get_db)) -> List[models.TourPackage]:
+    return list(crud.list_tour_packages(db))
+
+
+@router.put("/{package_id}", response_model=schemas.TourPackage)
+def update_package(
+    package_id: int,
+    package_in: schemas.TourPackageUpdate,
+    db: Session = Depends(get_db),
+) -> models.TourPackage:
+    package = crud.get_tour_package(db, package_id)
+    if not package:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Package not found")
+    return crud.update_tour_package(db, package, package_in)
+
+
+@router.delete("/{package_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_package(package_id: int, db: Session = Depends(get_db)) -> Response:
+    package = crud.get_tour_package(db, package_id)
+    if not package:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Package not found")
+    crud.delete_tour_package(db, package)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,0 +1,340 @@
+"""CRUD helper functions used by the API routers."""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, selectinload
+
+from . import models, schemas
+
+
+# Client helpers
+
+def create_client(session: Session, client_in: schemas.ClientCreate) -> models.Client:
+    client = models.Client(**client_in.model_dump())
+    session.add(client)
+    session.flush()
+    return client
+
+
+def list_clients(session: Session) -> Sequence[models.Client]:
+    statement = select(models.Client).order_by(models.Client.name)
+    return session.scalars(statement).all()
+
+
+def get_client(session: Session, client_id: int) -> models.Client | None:
+    return session.get(models.Client, client_id)
+
+
+def update_client(session: Session, client: models.Client, client_in: schemas.ClientUpdate) -> models.Client:
+    for field, value in client_in.model_dump(exclude_unset=True).items():
+        setattr(client, field, value)
+    session.add(client)
+    session.flush()
+    return client
+
+
+def delete_client(session: Session, client: models.Client) -> None:
+    session.delete(client)
+    session.flush()
+
+
+# Lead helpers
+
+def create_lead(session: Session, lead_in: schemas.LeadCreate) -> models.Lead:
+    lead = models.Lead(**lead_in.model_dump())
+    session.add(lead)
+    session.flush()
+    return lead
+
+
+def list_leads(session: Session) -> Sequence[models.Lead]:
+    statement = select(models.Lead).order_by(models.Lead.created_at.desc())
+    return session.scalars(statement).all()
+
+
+def get_lead(session: Session, lead_id: int) -> models.Lead | None:
+    return session.get(models.Lead, lead_id)
+
+
+def update_lead(session: Session, lead: models.Lead, lead_in: schemas.LeadUpdate) -> models.Lead:
+    for field, value in lead_in.model_dump(exclude_unset=True).items():
+        setattr(lead, field, value)
+    session.add(lead)
+    session.flush()
+    return lead
+
+
+def delete_lead(session: Session, lead: models.Lead) -> None:
+    session.delete(lead)
+    session.flush()
+
+
+def convert_lead_to_client(session: Session, lead: models.Lead) -> models.Client:
+    if lead.client:
+        return lead.client
+
+    client_data = {
+        "name": lead.name,
+        "email": lead.email,
+        "notes": lead.notes,
+    }
+    client = models.Client(**{key: value for key, value in client_data.items() if value is not None})
+    session.add(client)
+    session.flush()
+
+    lead.client_id = client.id
+    lead.status = "converted"
+    session.add(lead)
+    session.flush()
+    return client
+
+
+# Tour package helpers
+
+def create_tour_package(session: Session, package_in: schemas.TourPackageCreate) -> models.TourPackage:
+    package = models.TourPackage(**package_in.model_dump())
+    session.add(package)
+    session.flush()
+    return package
+
+
+def list_tour_packages(session: Session) -> Sequence[models.TourPackage]:
+    statement = select(models.TourPackage).order_by(models.TourPackage.name)
+    return session.scalars(statement).all()
+
+
+def get_tour_package(session: Session, package_id: int) -> models.TourPackage | None:
+    return session.get(models.TourPackage, package_id)
+
+
+def update_tour_package(
+    session: Session, package: models.TourPackage, package_in: schemas.TourPackageUpdate
+) -> models.TourPackage:
+    for field, value in package_in.model_dump(exclude_unset=True).items():
+        setattr(package, field, value)
+    session.add(package)
+    session.flush()
+    return package
+
+
+def delete_tour_package(session: Session, package: models.TourPackage) -> None:
+    session.delete(package)
+    session.flush()
+
+
+# Itinerary helpers
+
+def create_itinerary(session: Session, itinerary_in: schemas.ItineraryCreate) -> models.Itinerary:
+    items_data = itinerary_in.model_dump().pop("items", [])
+    itinerary = models.Itinerary(**itinerary_in.model_dump(exclude={"items"}))
+    session.add(itinerary)
+    session.flush()
+
+    for item in items_data:
+        itinerary_item = models.ItineraryItem(itinerary_id=itinerary.id, **item)
+        session.add(itinerary_item)
+    session.flush()
+    return itinerary
+
+
+def list_itineraries(session: Session) -> Sequence[models.Itinerary]:
+    statement = (
+        select(models.Itinerary)
+        .options(
+            selectinload(models.Itinerary.items),
+            selectinload(models.Itinerary.client),
+            selectinload(models.Itinerary.tour_package),
+        )
+        .order_by(models.Itinerary.start_date)
+    )
+    return session.scalars(statement).unique().all()
+
+
+def get_itinerary(session: Session, itinerary_id: int) -> models.Itinerary | None:
+    statement = (
+        select(models.Itinerary)
+        .where(models.Itinerary.id == itinerary_id)
+        .options(
+            selectinload(models.Itinerary.items),
+            selectinload(models.Itinerary.client),
+            selectinload(models.Itinerary.tour_package),
+        )
+    )
+    return session.scalars(statement).unique().first()
+
+
+def update_itinerary(
+    session: Session, itinerary: models.Itinerary, itinerary_in: schemas.ItineraryUpdate
+) -> models.Itinerary:
+    data = itinerary_in.model_dump(exclude_unset=True)
+    items_data = data.pop("items", None)
+
+    for field, value in data.items():
+        setattr(itinerary, field, value)
+
+    if items_data is not None:
+        itinerary.items.clear()
+        session.flush()
+        for item in items_data:
+            itinerary.items.append(models.ItineraryItem(**item))
+
+    session.add(itinerary)
+    session.flush()
+    return itinerary
+
+
+def delete_itinerary(session: Session, itinerary: models.Itinerary) -> None:
+    session.delete(itinerary)
+    session.flush()
+
+
+def duplicate_itinerary(session: Session, itinerary: models.Itinerary) -> models.Itinerary:
+    clone = models.Itinerary(
+        client_id=itinerary.client_id,
+        tour_package_id=itinerary.tour_package_id,
+        title=f"{itinerary.title} (Copy)",
+        start_date=itinerary.start_date,
+        end_date=itinerary.end_date,
+        total_price=itinerary.total_price,
+        status="draft",
+    )
+    session.add(clone)
+    session.flush()
+
+    for item in itinerary.items:
+        session.add(
+            models.ItineraryItem(
+                itinerary_id=clone.id,
+                day_number=item.day_number,
+                title=item.title,
+                description=item.description,
+                location=item.location,
+                start_time=item.start_time,
+                end_time=item.end_time,
+            )
+        )
+    session.flush()
+    return clone
+
+
+# Finance helpers
+
+def create_invoice(session: Session, invoice_in: schemas.InvoiceCreate) -> models.Invoice:
+    invoice = models.Invoice(**invoice_in.model_dump())
+    session.add(invoice)
+    session.flush()
+    return invoice
+
+
+def list_invoices(session: Session) -> Sequence[models.Invoice]:
+    statement = (
+        select(models.Invoice)
+        .options(selectinload(models.Invoice.payments))
+        .order_by(models.Invoice.issue_date.desc())
+    )
+    return session.scalars(statement).unique().all()
+
+
+def get_invoice(session: Session, invoice_id: int) -> models.Invoice | None:
+    statement = (
+        select(models.Invoice)
+        .where(models.Invoice.id == invoice_id)
+        .options(selectinload(models.Invoice.payments))
+    )
+    return session.scalars(statement).unique().first()
+
+
+def update_invoice(session: Session, invoice: models.Invoice, invoice_in: schemas.InvoiceUpdate) -> models.Invoice:
+    for field, value in invoice_in.model_dump(exclude_unset=True).items():
+        setattr(invoice, field, value)
+    session.add(invoice)
+    session.flush()
+    return invoice
+
+
+def delete_invoice(session: Session, invoice: models.Invoice) -> None:
+    session.delete(invoice)
+    session.flush()
+
+
+def create_payment(session: Session, payment_in: schemas.PaymentCreate) -> models.Payment:
+    payment = models.Payment(**payment_in.model_dump())
+    session.add(payment)
+    session.flush()
+    return payment
+
+
+def list_payments(session: Session) -> Sequence[models.Payment]:
+    statement = select(models.Payment).order_by(models.Payment.paid_on.desc())
+    return session.scalars(statement).all()
+
+
+def get_payment(session: Session, payment_id: int) -> models.Payment | None:
+    return session.get(models.Payment, payment_id)
+
+
+def update_payment(session: Session, payment: models.Payment, payment_in: schemas.PaymentUpdate) -> models.Payment:
+    for field, value in payment_in.model_dump(exclude_unset=True).items():
+        setattr(payment, field, value)
+    session.add(payment)
+    session.flush()
+    return payment
+
+
+def delete_payment(session: Session, payment: models.Payment) -> None:
+    session.delete(payment)
+    session.flush()
+
+
+def create_expense(session: Session, expense_in: schemas.ExpenseCreate) -> models.Expense:
+    expense = models.Expense(**expense_in.model_dump())
+    session.add(expense)
+    session.flush()
+    return expense
+
+
+def list_expenses(session: Session) -> Sequence[models.Expense]:
+    statement = select(models.Expense).order_by(models.Expense.incurred_on.desc())
+    return session.scalars(statement).all()
+
+
+def get_expense(session: Session, expense_id: int) -> models.Expense | None:
+    return session.get(models.Expense, expense_id)
+
+
+def update_expense(session: Session, expense: models.Expense, expense_in: schemas.ExpenseUpdate) -> models.Expense:
+    for field, value in expense_in.model_dump(exclude_unset=True).items():
+        setattr(expense, field, value)
+    session.add(expense)
+    session.flush()
+    return expense
+
+
+def delete_expense(session: Session, expense: models.Expense) -> None:
+    session.delete(expense)
+    session.flush()
+
+
+def sales_report(session: Session) -> dict[str, dict[str, float]]:
+    invoices = list_invoices(session)
+    payments = list_payments(session)
+
+    monthly: dict[str, dict[str, Decimal]] = {}
+    for invoice in invoices:
+        month = invoice.issue_date.strftime("%Y-%m") if invoice.issue_date else "unknown"
+        summary = monthly.setdefault(month, {"invoiced": Decimal("0"), "paid": Decimal("0")})
+        summary["invoiced"] += Decimal(invoice.amount)
+    for payment in payments:
+        month = payment.paid_on.strftime("%Y-%m") if payment.paid_on else "unknown"
+        summary = monthly.setdefault(month, {"invoiced": Decimal("0"), "paid": Decimal("0")})
+        summary["paid"] += Decimal(payment.amount)
+
+    return {
+        "monthly": {
+            month: {"invoiced": float(values["invoiced"]), "paid": float(values["paid"])}
+            for month, values in sorted(monthly.items())
+        }
+    }

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,31 @@
+"""Database configuration and session management for the Tour Planner app."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
+
+DATABASE_URL = "sqlite:///./tour_planner.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}, future=True, echo=False
+)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+Base = declarative_base()
+
+
+@contextmanager
+def session_scope() -> Generator[Session, None, None]:
+    """Provide a transactional scope around a series of operations."""
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,26 @@
+"""FastAPI application entrypoint for the tour itinerary builder."""
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .api import router as api_router
+from .api.deps import get_db
+from .database import Base, engine
+
+Base.metadata.create_all(bind=engine)
+
+
+def create_application() -> FastAPI:
+    app = FastAPI(title="Tour Planner API", version="2.0.0")
+    app.include_router(api_router)
+
+    @app.get("/", tags=["health"], summary="Service healthcheck")
+    def healthcheck() -> dict[str, str]:
+        return {"status": "ok", "message": "Tour Planner API is running"}
+
+    return app
+
+
+app = create_application()
+
+__all__ = ["app", "create_application", "get_db"]

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,137 @@
+"""SQLAlchemy models for the Tour Planner backend."""
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from sqlalchemy import Boolean, CheckConstraint, Column, Date, DateTime, ForeignKey, Integer, Numeric, String, Text
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+
+class TimestampMixin:
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+
+class Client(Base, TimestampMixin):
+    __tablename__ = "clients"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(120), nullable=False)
+    email = Column(String(120), nullable=True, unique=True)
+    phone = Column(String(50), nullable=True)
+    address = Column(String(200), nullable=True)
+    notes = Column(Text, nullable=True)
+
+    itineraries = relationship("Itinerary", back_populates="client", cascade="all, delete-orphan")
+    invoices = relationship("Invoice", back_populates="client", cascade="all, delete-orphan")
+    leads = relationship("Lead", back_populates="client", cascade="all, delete-orphan")
+
+
+class Lead(Base, TimestampMixin):
+    __tablename__ = "leads"
+
+    id = Column(Integer, primary_key=True, index=True)
+    client_id = Column(Integer, ForeignKey("clients.id"), nullable=True)
+    name = Column(String(120), nullable=False)
+    email = Column(String(120), nullable=True)
+    source = Column(String(120), nullable=True)
+    status = Column(String(50), nullable=False, default="new")
+    notes = Column(Text, nullable=True)
+
+    client = relationship("Client", back_populates="leads")
+
+
+class TourPackage(Base, TimestampMixin):
+    __tablename__ = "tour_packages"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(150), nullable=False)
+    destination = Column(String(150), nullable=False)
+    duration_days = Column(Integer, nullable=False)
+    base_price = Column(Numeric(10, 2), nullable=False)
+    description = Column(Text, nullable=True)
+
+    itineraries = relationship("Itinerary", back_populates="tour_package")
+
+
+class Itinerary(Base, TimestampMixin):
+    __tablename__ = "itineraries"
+
+    id = Column(Integer, primary_key=True, index=True)
+    client_id = Column(Integer, ForeignKey("clients.id"), nullable=False)
+    tour_package_id = Column(Integer, ForeignKey("tour_packages.id"), nullable=True)
+    title = Column(String(150), nullable=False)
+    start_date = Column(Date, nullable=False)
+    end_date = Column(Date, nullable=False)
+    total_price = Column(Numeric(10, 2), nullable=True)
+    status = Column(String(50), nullable=False, default="draft")
+
+    client = relationship("Client", back_populates="itineraries")
+    tour_package = relationship("TourPackage", back_populates="itineraries")
+    items = relationship("ItineraryItem", back_populates="itinerary", cascade="all, delete-orphan")
+    invoices = relationship("Invoice", back_populates="itinerary")
+
+    __table_args__ = (
+        CheckConstraint("end_date >= start_date", name="check_dates"),
+    )
+
+
+class ItineraryItem(Base, TimestampMixin):
+    __tablename__ = "itinerary_items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    itinerary_id = Column(Integer, ForeignKey("itineraries.id"), nullable=False)
+    day_number = Column(Integer, nullable=False)
+    title = Column(String(150), nullable=False)
+    description = Column(Text, nullable=True)
+    location = Column(String(150), nullable=True)
+    start_time = Column(String(20), nullable=True)
+    end_time = Column(String(20), nullable=True)
+
+    itinerary = relationship("Itinerary", back_populates="items")
+
+
+class Invoice(Base, TimestampMixin):
+    __tablename__ = "invoices"
+
+    id = Column(Integer, primary_key=True, index=True)
+    client_id = Column(Integer, ForeignKey("clients.id"), nullable=False)
+    itinerary_id = Column(Integer, ForeignKey("itineraries.id"), nullable=True)
+    issue_date = Column(Date, default=date.today, nullable=False)
+    due_date = Column(Date, nullable=False)
+    amount = Column(Numeric(10, 2), nullable=False)
+    currency = Column(String(10), nullable=False, default="USD")
+    status = Column(String(50), nullable=False, default="unpaid")
+
+    client = relationship("Client", back_populates="invoices")
+    itinerary = relationship("Itinerary", back_populates="invoices")
+    payments = relationship("Payment", back_populates="invoice", cascade="all, delete-orphan")
+
+
+class Payment(Base, TimestampMixin):
+    __tablename__ = "payments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    invoice_id = Column(Integer, ForeignKey("invoices.id"), nullable=False)
+    amount = Column(Numeric(10, 2), nullable=False)
+    currency = Column(String(10), nullable=False, default="USD")
+    paid_on = Column(Date, default=date.today, nullable=False)
+    method = Column(String(50), nullable=True)
+    notes = Column(Text, nullable=True)
+
+    invoice = relationship("Invoice", back_populates="payments")
+
+
+class Expense(Base, TimestampMixin):
+    __tablename__ = "expenses"
+
+    id = Column(Integer, primary_key=True, index=True)
+    description = Column(String(200), nullable=False)
+    amount = Column(Numeric(10, 2), nullable=False)
+    currency = Column(String(10), nullable=False, default="USD")
+    category = Column(String(100), nullable=True)
+    incurred_on = Column(Date, default=date.today, nullable=False)
+    reimbursable = Column(Boolean, default=False)
+

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,231 @@
+"""Pydantic schemas describing the API payloads."""
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class TimestampMixin(BaseModel):
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ClientBase(BaseModel):
+    name: str = Field(..., description="Client full name")
+    email: Optional[str] = Field(None, description="Primary email address")
+    phone: Optional[str] = None
+    address: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class ClientCreate(ClientBase):
+    pass
+
+
+class ClientUpdate(BaseModel):
+    name: Optional[str] = None
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    address: Optional[str] = None
+    notes: Optional[str] = None
+
+
+
+class Client(ClientBase, TimestampMixin):
+    id: int
+
+
+class LeadBase(BaseModel):
+    name: str
+    email: Optional[str] = None
+    source: Optional[str] = None
+    status: str = Field("new", description="Lead status e.g. new, contacted, qualified")
+    notes: Optional[str] = None
+    client_id: Optional[int] = None
+
+
+class LeadCreate(LeadBase):
+    pass
+
+
+class LeadUpdate(BaseModel):
+    name: Optional[str] = None
+    email: Optional[str] = None
+    source: Optional[str] = None
+    status: Optional[str] = None
+    notes: Optional[str] = None
+    client_id: Optional[int] = None
+
+
+class LeadConversionResult(BaseModel):
+    lead: Lead
+    client: Client
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class Lead(LeadBase, TimestampMixin):
+    id: int
+
+
+class TourPackageBase(BaseModel):
+    name: str
+    destination: str
+    duration_days: int
+    base_price: Decimal
+    description: Optional[str] = None
+
+
+class TourPackageCreate(TourPackageBase):
+    pass
+
+
+class TourPackageUpdate(BaseModel):
+    name: Optional[str] = None
+    destination: Optional[str] = None
+    duration_days: Optional[int] = None
+    base_price: Optional[Decimal] = None
+    description: Optional[str] = None
+
+
+class TourPackage(TourPackageBase, TimestampMixin):
+    id: int
+
+
+class ItineraryItemBase(BaseModel):
+    day_number: int
+    title: str
+    description: Optional[str] = None
+    location: Optional[str] = None
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+
+    @field_validator("day_number")
+    @classmethod
+    def validate_day_number(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("day_number must be greater than zero")
+        return value
+
+
+class ItineraryItemCreate(ItineraryItemBase):
+    pass
+
+
+class ItineraryItem(ItineraryItemBase, TimestampMixin):
+    id: int
+
+
+class ItineraryBase(BaseModel):
+    client_id: int
+    tour_package_id: Optional[int] = None
+    title: str
+    start_date: date
+    end_date: date
+    total_price: Optional[Decimal] = None
+    status: str = "draft"
+
+
+class ItineraryCreate(ItineraryBase):
+    items: List[ItineraryItemCreate] = Field(default_factory=list)
+
+
+class ItineraryUpdate(BaseModel):
+    client_id: Optional[int] = None
+    tour_package_id: Optional[int] = None
+    title: Optional[str] = None
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    total_price: Optional[Decimal] = None
+    status: Optional[str] = None
+    items: Optional[List[ItineraryItemCreate]] = None
+
+
+class Itinerary(ItineraryBase, TimestampMixin):
+    id: int
+    items: List[ItineraryItem]
+
+
+class InvoiceBase(BaseModel):
+    client_id: int
+    itinerary_id: Optional[int] = None
+    issue_date: date
+    due_date: date
+    amount: Decimal
+    currency: str = "USD"
+    status: str = "unpaid"
+
+
+class InvoiceCreate(InvoiceBase):
+    pass
+
+
+class InvoiceUpdate(BaseModel):
+    client_id: Optional[int] = None
+    itinerary_id: Optional[int] = None
+    issue_date: Optional[date] = None
+    due_date: Optional[date] = None
+    amount: Optional[Decimal] = None
+    currency: Optional[str] = None
+    status: Optional[str] = None
+
+
+class Invoice(InvoiceBase, TimestampMixin):
+    id: int
+
+
+class PaymentBase(BaseModel):
+    invoice_id: int
+    amount: Decimal
+    currency: str = "USD"
+    paid_on: date
+    method: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class PaymentCreate(PaymentBase):
+    pass
+
+
+class PaymentUpdate(BaseModel):
+    invoice_id: Optional[int] = None
+    amount: Optional[Decimal] = None
+    currency: Optional[str] = None
+    paid_on: Optional[date] = None
+    method: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class Payment(PaymentBase, TimestampMixin):
+    id: int
+
+
+class ExpenseBase(BaseModel):
+    description: str
+    amount: Decimal
+    currency: str = "USD"
+    category: Optional[str] = None
+    incurred_on: date
+    reimbursable: bool = False
+
+
+class ExpenseCreate(ExpenseBase):
+    pass
+
+
+class ExpenseUpdate(BaseModel):
+    description: Optional[str] = None
+    amount: Optional[Decimal] = None
+    currency: Optional[str] = None
+    category: Optional[str] = None
+    incurred_on: Optional[date] = None
+    reimbursable: Optional[bool] = None
+
+
+class Expense(ExpenseBase, TimestampMixin):
+    id: int

--- a/app/templates/itinerary.html
+++ b/app/templates/itinerary.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ itinerary.title }} - Itinerary</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; color: #222; }
+        h1, h2, h3 { color: #0b3d59; }
+        .header { border-bottom: 2px solid #0b3d59; margin-bottom: 20px; }
+        .section { margin-bottom: 30px; }
+        .day { margin-bottom: 15px; padding: 10px; border: 1px solid #ccc; border-radius: 6px; }
+        .meta { font-size: 0.9em; color: #555; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>{{ itinerary.title }}</h1>
+        <p class="meta">{{ itinerary.start_date }} to {{ itinerary.end_date }} &bull; Status: {{ itinerary.status|title }}</p>
+        <p class="meta">Client: {{ itinerary.client.name }}{% if itinerary.client.email %} &lt;{{ itinerary.client.email }}&gt;{% endif %}</p>
+        {% if itinerary.tour_package %}
+        <p class="meta">Package: {{ itinerary.tour_package.name }} ({{ itinerary.tour_package.destination }})</p>
+        {% endif %}
+        {% if itinerary.total_price %}
+        <p class="meta">Total Price: {{ '%.2f'|format(itinerary.total_price) }}</p>
+        {% endif %}
+    </div>
+
+    <div class="section">
+        <h2>Daily Schedule</h2>
+        {% for item in itinerary.items|sort(attribute='day_number') %}
+        <div class="day">
+            <h3>Day {{ item.day_number }}: {{ item.title }}</h3>
+            {% if item.location %}<p><strong>Location:</strong> {{ item.location }}</p>{% endif %}
+            {% if item.start_time or item.end_time %}
+                <p><strong>Time:</strong> {{ item.start_time or 'TBC' }} - {{ item.end_time or 'TBC' }}</p>
+            {% endif %}
+            {% if item.description %}<p>{{ item.description }}</p>{% endif %}
+        </div>
+        {% endfor %}
+    </div>
+</body>
+</html>

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,24 @@
+"""Utility helpers for itinerary formatting."""
+from __future__ import annotations
+
+from typing import Iterable
+
+from jinja2 import Environment, PackageLoader, select_autoescape
+
+from . import models
+
+
+def render_itinerary(itinerary: models.Itinerary) -> str:
+    """Render an itinerary into a printable text/HTML hybrid document."""
+    env = Environment(
+        loader=PackageLoader("app", "templates"),
+        autoescape=select_autoescape(["html", "xml"]),
+        enable_async=False,
+    )
+    template = env.get_template("itinerary.html")
+    return template.render(itinerary=itinerary)
+
+
+def compute_outstanding_balance(payments: Iterable[models.Payment], amount_due: float) -> float:
+    total_paid = sum(float(payment.amount) for payment in payments)
+    return round(amount_due - total_paid, 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
+SQLAlchemy==2.0.29
+pydantic==2.6.4
+alembic==1.13.1
+python-multipart==0.0.9
+Jinja2==3.1.3
+pytest==8.1.1
+httpx==0.27.0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.database import Base  # noqa: E402
+from app.main import app, get_db  # noqa: E402
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+    future=True,
+)
+TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+def reset_database() -> None:
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+reset_database()
+
+
+def override_get_db() -> Generator[Session, None, None]:
+    db = TestingSessionLocal()
+    try:
+        yield db
+        db.commit()
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+
+@pytest.fixture
+def api_client() -> Generator[TestClient, None, None]:
+    reset_database()
+    with TestClient(app) as client:
+        yield client
+
+
+def create_sample_client(client: TestClient) -> int:
+    response = client.post(
+        "/clients",
+        json={"name": "Alice Traveler", "email": "alice@example.com"},
+    )
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def test_create_itinerary_and_print(api_client: TestClient) -> None:
+    client_id = create_sample_client(api_client)
+    itinerary_payload = {
+        "client_id": client_id,
+        "title": "Bali Adventure",
+        "start_date": str(date(2024, 6, 1)),
+        "end_date": str(date(2024, 6, 5)),
+        "status": "confirmed",
+        "items": [
+            {
+                "day_number": 1,
+                "title": "Arrival",
+                "description": "Airport pickup and hotel check-in.",
+                "location": "Denpasar",
+            },
+            {
+                "day_number": 2,
+                "title": "Beach Day",
+                "description": "Relax at Nusa Dua Beach.",
+                "location": "Nusa Dua",
+            },
+        ],
+    }
+
+    itinerary_response = api_client.post("/itineraries", json=itinerary_payload)
+    assert itinerary_response.status_code == 201
+    itinerary_id = itinerary_response.json()["id"]
+
+    printable = api_client.get(f"/itineraries/{itinerary_id}/print")
+    assert printable.status_code == 200
+    body = printable.text
+    assert "Bali Adventure" in body
+    assert "Day 1" in body
+    assert "Nusa Dua" in body
+
+
+def test_finance_summary_flow(api_client: TestClient) -> None:
+    client_id = create_sample_client(api_client)
+
+    invoice_payload = {
+        "client_id": client_id,
+        "issue_date": str(date(2024, 6, 1)),
+        "due_date": str(date(2024, 6, 15)),
+        "amount": "1500.00",
+        "currency": "USD",
+    }
+    invoice_response = api_client.post("/finance/invoices", json=invoice_payload)
+    assert invoice_response.status_code == 201
+    invoice_id = invoice_response.json()["id"]
+
+    payment_payload = {
+        "invoice_id": invoice_id,
+        "amount": "500.00",
+        "paid_on": str(date(2024, 6, 2)),
+        "currency": "USD",
+    }
+    payment_response = api_client.post("/finance/payments", json=payment_payload)
+    assert payment_response.status_code == 201
+
+    expense_payload = {
+        "description": "Hotel deposit",
+        "amount": "300.00",
+        "incurred_on": str(date(2024, 5, 25)),
+        "currency": "USD",
+    }
+    expense_response = api_client.post("/finance/expenses", json=expense_payload)
+    assert expense_response.status_code == 201
+
+    summary = api_client.get("/finance/summary")
+    assert summary.status_code == 200
+    data = summary.json()
+    assert data["total_invoiced"] == 1500.0
+    assert data["total_paid"] == 500.0
+    assert data["total_expenses"] == 300.0
+    assert data["outstanding"] == 1000.0
+    assert data["profitability"] == 200.0
+
+
+def test_lead_conversion_creates_client(api_client: TestClient) -> None:
+    lead_payload = {"name": "New Lead", "email": "lead@example.com", "notes": "Interested in Bali"}
+    lead_response = api_client.post("/leads", json=lead_payload)
+    assert lead_response.status_code == 201
+    lead_id = lead_response.json()["id"]
+
+    conversion = api_client.post(f"/leads/{lead_id}/convert")
+    assert conversion.status_code == 200
+    body = conversion.json()
+    assert body["lead"]["status"] == "converted"
+    client_id = body["client"]["id"]
+
+    client = api_client.get(f"/clients/{client_id}")
+    assert client.status_code == 200
+    assert client.json()["email"] == "lead@example.com"
+
+
+def test_duplicate_itinerary_creates_draft_copy(api_client: TestClient) -> None:
+    client_id = create_sample_client(api_client)
+    itinerary_payload = {
+        "client_id": client_id,
+        "title": "Original Trip",
+        "start_date": str(date(2024, 7, 1)),
+        "end_date": str(date(2024, 7, 3)),
+        "status": "confirmed",
+        "items": [
+            {
+                "day_number": 1,
+                "title": "Arrival",
+                "description": "Check-in",
+            }
+        ],
+    }
+    itinerary_response = api_client.post("/itineraries", json=itinerary_payload)
+    assert itinerary_response.status_code == 201
+    itinerary_id = itinerary_response.json()["id"]
+
+    clone_response = api_client.post(f"/itineraries/{itinerary_id}/duplicate")
+    assert clone_response.status_code == 201
+    clone_data = clone_response.json()
+
+    assert clone_data["id"] != itinerary_id
+    assert clone_data["title"].startswith("Original Trip")
+    assert clone_data["status"] == "draft"
+    assert len(clone_data["items"]) == 1


### PR DESCRIPTION
## Summary
- refactor the FastAPI application into modular routers with shared dependencies and namespaced finance/report endpoints
- extend CRUD helpers and schemas to support lead conversion, itinerary duplication, and partial updates across resources
- refresh documentation and automated tests to cover the new routes and behaviors, including lead conversion and itinerary cloning

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6484474548329bf9db5c45758f60f